### PR TITLE
Add conversion of "get_page" to FTML PageInfo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ before_script:
   - .travis/clippy.sh setup
   # Setup database
   - .travis/database.sh setup
+  # Add FTML for support
+  - .travis/download.sh ftml
 
 script:
   # Ensure code is rustfmt'd

--- a/.travis/download.sh
+++ b/.travis/download.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -eu
+
+cd ..
+
+for name in "$@"; do
+	repo="https://github.com/Nu-SCPTheme/$name"
+	echo "Cloning $repo..."
+	git clone --depth=50 --branch=master "$repo"
+	echo "Currently on commit:"
+	(cd "$name" && git rev-parse HEAD)
+done

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
+]
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+
+[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,6 +278,7 @@ dependencies = [
  "cfg-if",
  "chrono",
  "diesel",
+ "ftml",
  "lazy_static",
  "log",
  "map_vec",
@@ -288,10 +316,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fallible-iterator"
@@ -314,6 +357,26 @@ name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+
+[[package]]
+name = "ftml"
+version = "0.2.19"
+dependencies = [
+ "arrayvec",
+ "chrono",
+ "either",
+ "lazy_static",
+ "log",
+ "percent-encoding",
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "str-macro",
+ "thiserror",
+]
 
 [[package]]
 name = "fuchsia-cprng"
@@ -441,6 +504,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
+name = "generic-array"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,6 +575,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,6 +634,12 @@ checksum = "43e9839b06bd5129fa636a93cb53601ffae739b8ff115841374d110cafb02cad"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "maybe-uninit"
@@ -699,10 +783,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
 
 [[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
+dependencies = [
+ "maplit",
+ "pest",
+ "sha-1",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -920,6 +1053,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
+name = "ryu"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,6 +1105,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78a7a12c167809363ec3bd7329fc0a3369056996de43c4b37ef3cd54a6ce4867"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd02c7587ec314570041b2754829f84d873ced14a96d1fd1823531e11db40573"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "fake-simd",
+ "opaque-debug",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,6 +1177,12 @@ name = "stable_deref_trait"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+
+[[package]]
+name = "str-macro"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0914339d16fabe5ae7c5abd3a55d9697801cc224154543f3a7e1396dba3426dd"
 
 [[package]]
 name = "subprocess"
@@ -1129,6 +1308,18 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-xid"

--- a/deepwell-core/Cargo.toml
+++ b/deepwell-core/Cargo.toml
@@ -22,6 +22,7 @@ arrayvec = "0.5"
 chrono = { version = "0.4", features = ["serde"] }
 cfg-if = "0.1"
 diesel = { version = "1", features = ["chrono", "network-address", "postgres"] }
+ftml = { path = "../../ftml" }
 lazy_static = "1"
 log = "0.4"
 map_vec = "0.3"

--- a/deepwell-core/Cargo.toml
+++ b/deepwell-core/Cargo.toml
@@ -17,12 +17,16 @@ workspace = ".."
 name = "deepwell_core"
 path = "src/lib.rs"
 
+[features]
+default = ["ftml_compat"]
+ftml_compat = ["ftml"]
+
 [dependencies]
 arrayvec = "0.5"
 chrono = { version = "0.4", features = ["serde"] }
 cfg-if = "0.1"
 diesel = { version = "1", features = ["chrono", "network-address", "postgres"] }
-ftml = { path = "../../ftml" }
+ftml = { path = "../../ftml", optional = true }
 lazy_static = "1"
 log = "0.4"
 map_vec = "0.3"

--- a/deepwell-core/src/models/page.rs
+++ b/deepwell-core/src/models/page.rs
@@ -18,9 +18,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use crate::scoring::Scoring;
 use super::prelude::*;
 use super::Votes;
+use crate::scoring::Scoring;
 
 #[derive(Serialize, Deserialize, Queryable, Debug, Clone, PartialEq, Eq)]
 pub struct Page {
@@ -79,17 +79,16 @@ impl Page {
     pub fn exists(&self) -> bool {
         self.deleted_at.is_none()
     }
-   
+
     #[cfg(feature = "ftml_compat")]
-    pub fn create_pageinfo<'a, TScoring: Scoring>(&self, votes: &Votes) -> ftml::PageInfoOwned {
+    pub fn into_pageinfo<TScoring: Scoring>(self, votes: Votes) -> ftml::PageInfoOwned {
         ftml::PageInfoOwned {
-            title: String::from(self.title()),
-            alt_title: match self.alt_title() { None => None, Some(s) => Some(String::from(s)) },
+            title: self.title.clone(),
+            alt_title: self.alt_title.clone(),
             tags: self.tags().to_vec(),
             header: None,
             subheader: None,
-            rating: TScoring::score(votes) as i32,
+            rating: TScoring::score(&votes),
         }
     }
 }
-

--- a/deepwell-core/src/models/page.rs
+++ b/deepwell-core/src/models/page.rs
@@ -82,10 +82,11 @@ impl Page {
 
     #[cfg(feature = "ftml_compat")]
     pub fn into_pageinfo<TScoring: Scoring>(self, votes: Votes) -> ftml::PageInfoOwned {
+        let Self { title, alt_title, tags, .. } = self;
         ftml::PageInfoOwned {
-            title: self.title.clone(),
-            alt_title: self.alt_title.clone(),
-            tags: self.tags().to_vec(),
+            title,
+            alt_title,
+            tags,
             header: None,
             subheader: None,
             rating: TScoring::score(&votes),

--- a/deepwell-core/src/models/page.rs
+++ b/deepwell-core/src/models/page.rs
@@ -78,3 +78,16 @@ impl Page {
         self.deleted_at.is_none()
     }
 }
+
+impl<'a> From<(Page, Votes)> for ftml::PageInfo<'a> {
+    fn from(p: (Page, Votes)) -> Self {
+        ftml::PageInfo {
+            title: p.0.title(),
+            alt_title: p.0.alt_title(),
+            tags: p.0.tags().iter().map(|s| &**s).collect(),
+            header: None,
+            subheader: None,
+            rating: p.1.sum(),
+        }
+    }
+}

--- a/deepwell-core/src/models/votes.rs
+++ b/deepwell-core/src/models/votes.rs
@@ -69,4 +69,13 @@ impl Votes {
     pub fn count_for_vote(&self, vote: i16) -> Option<u32> {
         self.distribution.get(&vote).copied()
     }
+
+    #[inline]
+    pub fn sum(&self) -> i16 {
+        let mut sum = 0;
+        for (vote, count) in self.distribution {
+            sum += vote * count;
+        }
+        sum
+    }
 }

--- a/deepwell-core/src/models/votes.rs
+++ b/deepwell-core/src/models/votes.rs
@@ -69,13 +69,4 @@ impl Votes {
     pub fn count_for_vote(&self, vote: i16) -> Option<u32> {
         self.distribution.get(&vote).copied()
     }
-
-    #[inline]
-    pub fn sum(&self) -> i16 {
-        let mut sum = 0;
-        for (vote, count) in self.distribution {
-            sum += vote * count;
-        }
-        sum
-    }
 }


### PR DESCRIPTION
The Deepwell call `get_page` returns the tuple `(Page, Votes)`, which describe the page's metadata and total number of votes, respectively. The FTML struct `PageInfo` also describes this, and is used in Markdown to HTML conversion. `From<(Page, Votes)>` has thus been implemented for `PageInfo` in order to ease communication between Deepwell assets and FTML assets.